### PR TITLE
Add minimal Windows workflow to build openconnect-wrapper DLL

### DIFF
--- a/.github/workflows/build-windows-dll.yml
+++ b/.github/workflows/build-windows-dll.yml
@@ -1,0 +1,72 @@
+name: Build openconnect-wrapper DLL on Windows
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-dll:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+            autoconf
+            automake
+            libtool
+            gettext
+            mingw-w64-x86_64-libxml2
+            mingw-w64-x86_64-openssl
+            mingw-w64-x86_64-zlib
+          msystem: MINGW64
+
+      - name: Generate configure script and build
+        run: |
+          # Ensure Unix line endings for autoconf input files
+          if [ -f configure.ac ]; then
+            sed -i 's/$//' configure.ac
+          fi
+
+          if [ -x ./autogen.sh ]; then
+            ./autogen.sh || { echo 'autogen.sh failed'; exit 1; }
+          fi
+
+          ./configure --with-java || { test -f config.log && cat config.log; exit 1; }
+          make
+
+      - name: Find built DLL
+        id: find_dll
+        run: |
+          echo 'Searching for *openconnect-wrapper*.dll in workspace...'
+          find . -maxdepth 8 -type f -name '*openconnect-wrapper*.dll' -print || true
+
+          DLL_PATH=$(find . -maxdepth 8 -type f -name '*openconnect-wrapper*.dll' | head -n 1)
+
+          if [ -z "$DLL_PATH" ]; then
+            echo '*openconnect-wrapper*.dll not found'
+            exit 1
+          fi
+
+          echo "Found DLL at $DLL_PATH"
+          echo "dll_path=$DLL_PATH" >> $GITHUB_OUTPUT
+
+      - name: Upload DLL as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openconnect-wrapper-windows-dll
+          path: ${{ steps.find_dll.outputs.dll_path }}


### PR DESCRIPTION
This PR introduces a **minimal, isolated Windows GitHub Actions workflow** to build the `openconnect-wrapper` DLL without touching any upstream source files.

Key points:
- new workflow: `.github/workflows/build-windows-dll.yml`
- runs only on `windows-latest` for tags matching `v*`
- uses `msys2/setup-msys2` to provision a MinGW64 build environment
- runs `./autogen.sh` (after normalizing `configure.ac` to Unix line endings)
- runs `./configure --with-java` and `make` inside MSYS2
- searches for `*openconnect-wrapper*.dll` and uploads the DLL as a build artifact via `actions/upload-artifact` (no release integration yet)

The goal is to have a clean, focused CI job dedicated to producing the Windows `openconnect-wrapper` DLL, which can then be downloaded from the workflow artifacts for further manual testing or packaging.